### PR TITLE
Add optional property to metadata.json validator

### DIFF
--- a/.validator/schema.json
+++ b/.validator/schema.json
@@ -54,6 +54,14 @@
       "description": "Filename for a license text file",
       "type": "string"
     },
+    "sdcardonly": {
+      "description": "When true, only allow installation onto an SD card (not internal memory)",
+      "type": "boolean"
+    },
+    "sourcecode": {
+      "description": "Optional pointer to the source code of the app",
+      "type": "string"
+    },
     "application": {
       "type": "array",
       "items": {

--- a/.validator/schema.json
+++ b/.validator/schema.json
@@ -58,10 +58,6 @@
       "description": "When true, only allow installation onto an SD card (not internal memory)",
       "type": "boolean"
     },
-    "sourcecode": {
-      "description": "Optional pointer to the source code of the app",
-      "type": "string"
-    },
     "application": {
       "type": "array",
       "items": {


### PR DESCRIPTION
Add optional property to metadata.json validator:

*) sdcardonly: boolean (app needs SD card to install/function)
